### PR TITLE
Nexus Leo Leo 

### DIFF
--- a/info_analysis.sh
+++ b/info_analysis.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PR_REPO="${PR_REPO:-THIRD-EYE-DOME/Omega9}"
+PR_NUMBER="${PR_NUMBER:-1}"
+RUN_REPO="${RUN_REPO:-FISK-DIMENSION/Omega9}"
+RUN_ID="${RUN_ID:-21902224487}"
+WORKSPACE_ROOT="${WORKSPACE_ROOT:-$PWD}"
+OUTPUT_PATH="${OUTPUT_PATH:-info_analysis_report.json}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+json_escape() {
+  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+}
+
+write_report() {
+  python3 - "$@" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+output_path = Path(sys.argv[1])
+payload = json.loads(sys.argv[2])
+output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+print(f"wrote {output_path}")
+PY
+}
+
+has_gh=false
+if command -v gh >/dev/null 2>&1; then
+  has_gh=true
+fi
+
+pr_data=""
+pr_error=""
+if [ "$has_gh" = true ]; then
+  if gh pr view "$PR_NUMBER" --repo "$PR_REPO" --json number,title,body,headRefName,files > "$TMP_DIR/pr.json" 2> "$TMP_DIR/pr.err"; then
+    pr_data="$(cat "$TMP_DIR/pr.json")"
+  else
+    pr_error="$(cat "$TMP_DIR/pr.err")"
+  fi
+else
+  pr_error="gh CLI not installed"
+fi
+
+run_log_path="$TMP_DIR/run.log"
+run_error=""
+run_excerpt=""
+if [ "$has_gh" = true ]; then
+  if gh run view "$RUN_ID" --repo "$RUN_REPO" --log > "$run_log_path" 2> "$TMP_DIR/run.err"; then
+    run_excerpt="$(tail -n 120 "$run_log_path")"
+  else
+    run_error="$(cat "$TMP_DIR/run.err")"
+  fi
+else
+  run_error="gh CLI not installed"
+fi
+
+# Scan workflow files for likely trigger/job issues.
+mapfile -t workflow_files < <(find "$WORKSPACE_ROOT" \( -type d -name node_modules -o -type d -name .git \) -prune -o -type f \( -path '*/.github/workflows/*.yml' -o -path '*/.github/workflows/*.yaml' \) -print 2>/dev/null | sort)
+
+workflow_scan_json='[]'
+if [ "${#workflow_files[@]}" -gt 0 ]; then
+  workflow_scan_json="$(python3 - "$WORKSPACE_ROOT" "${workflow_files[@]}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+workspace = Path(sys.argv[1]).resolve()
+files = [Path(p) for p in sys.argv[2:]]
+issues = []
+
+for file_path in files:
+    text = file_path.read_text(encoding='utf-8', errors='replace')
+    rel = str(file_path.resolve().relative_to(workspace))
+    lines = text.splitlines()
+
+    has_on = bool(re.search(r'(?m)^\s*on\s*:', text))
+    has_jobs = bool(re.search(r'(?m)^\s*jobs\s*:', text))
+
+    if not has_on:
+        issues.append({
+            "file": rel,
+            "severity": "error",
+            "code": "missing_on",
+            "message": "Workflow file has no top-level 'on:' trigger block."
+        })
+
+    if not has_jobs:
+        issues.append({
+            "file": rel,
+            "severity": "error",
+            "code": "missing_jobs",
+            "message": "Workflow file has no top-level 'jobs:' block; this can produce 'No jobs were run'."
+        })
+
+    for i, line in enumerate(lines, start=1):
+        if re.match(r'^\s*on\s*:\s*\{\s*\}\s*$', line):
+            issues.append({
+                "file": rel,
+                "severity": "warning",
+                "code": "empty_on",
+                "line": i,
+                "message": "Trigger block is explicitly empty (on: {}), so no events can start jobs."
+            })
+
+        if re.match(r'^\s*jobs\s*:\s*\{\s*\}\s*$', line):
+            issues.append({
+                "file": rel,
+                "severity": "warning",
+                "code": "empty_jobs",
+                "line": i,
+                "message": "Jobs block is explicitly empty (jobs: {}), so no jobs can run."
+            })
+
+print(json.dumps(issues))
+PY
+)"
+fi
+
+# Basic diagnostics from run logs (pattern-driven, no hard dependency on GH output format).
+run_diagnostics='[]'
+if [ -s "$run_log_path" ]; then
+  run_diagnostics="$(python3 - "$run_log_path" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+log = Path(sys.argv[1]).read_text(encoding='utf-8', errors='replace')
+diags = []
+
+patterns = [
+    (r'No jobs were run', 'no_jobs_ran', "GitHub Actions accepted the workflow but scheduled zero jobs; usually trigger mismatch or empty/missing jobs block."),
+    (r'workflow .* is not valid', 'invalid_workflow_yaml', "Workflow syntax/validation error; inspect YAML structure and required keys."),
+    (r'No event triggers defined in `on`', 'missing_trigger', "Workflow appears to be missing valid event triggers under 'on:'."),
+    (r'The workflow is not valid\.', 'workflow_not_valid', "Workflow did not pass GitHub validation.")
+]
+
+for rx, code, msg in patterns:
+    if re.search(rx, log, flags=re.IGNORECASE):
+        diags.append({"code": code, "message": msg})
+
+print(json.dumps(diags))
+PY
+)"
+fi
+
+python3 - "$OUTPUT_PATH" "$PR_REPO" "$PR_NUMBER" "$RUN_REPO" "$RUN_ID" "$has_gh" "$pr_data" "$pr_error" "$run_error" "$run_excerpt" "$workflow_scan_json" "$run_diagnostics" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+
+(
+    output_path,
+    pr_repo,
+    pr_number,
+    run_repo,
+    run_id,
+    has_gh,
+    pr_data,
+    pr_error,
+    run_error,
+    run_excerpt,
+    workflow_scan_json,
+    run_diagnostics,
+) = sys.argv[1:]
+
+payload = {
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "inputs": {
+        "pr_repo": pr_repo,
+        "pr_number": int(pr_number),
+        "run_repo": run_repo,
+        "run_id": int(run_id),
+    },
+    "environment": {
+        "gh_installed": has_gh == "true",
+    },
+    "pr": {
+        "fetched": bool(pr_data),
+        "error": pr_error or None,
+        "data": json.loads(pr_data) if pr_data else None,
+    },
+    "run": {
+        "logs_fetched": run_error == "" and run_excerpt != "",
+        "error": run_error or None,
+        "log_excerpt_tail": run_excerpt or None,
+        "diagnostics": json.loads(run_diagnostics),
+    },
+    "workflow_scan": {
+        "issues": json.loads(workflow_scan_json),
+    },
+}
+
+with open(output_path, "w", encoding="utf-8") as f:
+    json.dump(payload, f, indent=2)
+    f.write("\n")
+
+print(f"wrote {output_path}")
+PY

--- a/info_analysis_report.json
+++ b/info_analysis_report.json
@@ -1,0 +1,26 @@
+{
+  "generated_at": "2026-02-11T11:50:08.819097+00:00",
+  "inputs": {
+    "pr_repo": "THIRD-EYE-DOME/Omega9",
+    "pr_number": 1,
+    "run_repo": "FISK-DIMENSION/Omega9",
+    "run_id": 21902224487
+  },
+  "environment": {
+    "gh_installed": false
+  },
+  "pr": {
+    "fetched": false,
+    "error": "gh CLI not installed",
+    "data": null
+  },
+  "run": {
+    "logs_fetched": false,
+    "error": "gh CLI not installed",
+    "log_excerpt_tail": null,
+    "diagnostics": []
+  },
+  "workflow_scan": {
+    "issues": []
+  }
+}

--- a/workflow_main_minimal_fix.yml
+++ b/workflow_main_minimal_fix.yml
@@ -1,0 +1,35 @@
+name: main
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint --if-present
+
+      - name: Test
+        run: npm test --if-present


### PR DESCRIPTION
### Motivation
- Provide an automated, reproducible way to diagnose the GitHub Actions startup failure "No jobs were run" and to collect PR / run metadata across the two related Omega9 repos. 
- Offer a minimal workflow YAML example that commonly resolves missing-trigger / missing-jobs startup issues for Node projects so maintainers have a safe patch suggestion.

### Description
- Add `info_analysis.sh`, an executable diagnostics script that attempts to fetch PR details and run logs via `gh`, scans workspace `.github/workflows` YAML files (pruning `node_modules` and `.git`) for missing/empty `on` or `jobs` blocks, and emits a machine-friendly JSON report to `info_analysis_report.json`.
- The script uses pattern checks to detect `missing_on`, `missing_jobs`, `empty_on`, and `empty_jobs` cases and records environment limitations (e.g., whether `gh` is installed) in the output.
- Add `workflow_main_minimal_fix.yml`, a minimal GitHub Actions workflow template that defines common `on` triggers and a concrete `jobs` block (checkout, setup Node, install, lint, test) as a suggested fix for "No jobs were run" errors.
- Include a sample `info_analysis_report.json` produced by running the script in the current environment to demonstrate output shape and failure modes.

### Testing
- Ran `./info_analysis.sh` successfully and confirmed it wrote `info_analysis_report.json` with detected environment status and workflow-scan results (script execution succeeded).
- Confirmed the script correctly recorded that `gh` was not installed and therefore remote PR/run fetches were not performed (report contains the CLI-missing error), which is the expected behavior when `gh` is unavailable.
- Attempted to install `gh` via `apt` but the installation failed due to proxy/repository `403 Forbidden`, so live GitHub API fetches were not executed and that limitation is captured in the report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698c66867348832383c725ca8da7adf9)